### PR TITLE
Fix overflowing tables

### DIFF
--- a/styles/pages/_content.scss
+++ b/styles/pages/_content.scss
@@ -417,6 +417,19 @@ main.page--article{
         }
     }
     
+    // Override some default MediaWiki values and some built-in values to make tables mobile-friendly
+    table.wikitable{
+        display: block;
+        border-width: 0px !important;
+        max-width: 100%;
+        overflow: auto;
+        background-color transparent;
+        
+        tbody{
+            background-color: #eff0f1;
+        }
+    }
+    
     div.thumbinner{
         margin: 0.5rem;
         padding: 0.5rem;

--- a/styles/pages/_content.scss
+++ b/styles/pages/_content.scss
@@ -423,7 +423,7 @@ main.page--article{
         border-width: 0px !important;
         max-width: 100%;
         overflow: auto;
-        background-color transparent;
+        background-color: transparent;
         
         tbody{
             background-color: #eff0f1;


### PR DESCRIPTION
Wikitables can sometimes overflow, making a bad experience on mobile devices. This adds a scrollbar on overflowing tables.